### PR TITLE
Update to new http.fetch syntax

### DIFF
--- a/oauth.v
+++ b/oauth.v
@@ -42,7 +42,7 @@ fn (app mut App) oauth_cb() {
 	d := 'client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&code=$code'
 	resp := http.post('https://github.com/login/oauth/access_token', d) or { return }
 	token := resp.text.find_between('access_token=', '&')
-	mut req := http.new_request('GET', 'https://api.github.com/user?access_token=$token', '') or { return }
+	mut req := http.get('https://api.github.com/user?access_token=$token') or { return }
 	req.add_header('User-Agent', 'V http client')
 	user_js := req.do() or { return }
 	gh_user := json.decode(GitHubUser, user_js.text) or {


### PR DESCRIPTION
This updates vorum to the new `http.fetch` syntax added in https://github.com/vlang/v/pull/3445